### PR TITLE
#36 fixed overlapping detections

### DIFF
--- a/src/models/oriented_object_detection.ts
+++ b/src/models/oriented_object_detection.ts
@@ -488,12 +488,14 @@ export class OrientedObjectDetection {
         (val, idx) => val / (areas[i] + areas[idx] - val)
       );
 
+      // keep only overlapping indexes
       const h_inds = hbbOvr
         .map((val, idx) => (val > 0 ? idx : -1))
         .filter(idx => idx !== -1 && idx !== i); // exclude self
 
       const tmp_order = order.filter(j => h_inds.includes(j));
 
+      // Recompute IOU for overlapping polygons
       for (let j = 0; j < tmp_order.length; j++) {
         const iou = iouPoly(polys[i], polys[tmp_order[j]]);
         hbbOvr[tmp_order[j]] = iou;


### PR DESCRIPTION
Previously, the NMS logic incorrectly used array positions instead of actual detection indices when filtering overlaps, leading to some overlapping detections not being suppressed.

<img width="927" alt="Screenshot 2025-04-23 at 11 46 03 AM" src="https://github.com/user-attachments/assets/c5cb5a2e-efc1-4d2c-bcfe-aa4b4dd5e18c" />
