### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: Main
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/decision-labs/geoai.js/security/code-scanning/1](https://github.com/decision-labs/geoai.js/security/code-scanning/1)

To fix this problem, you should add a explicit `permissions` block to the workflow file, ideally at the root level (before the `jobs:` key). This block should specify the minimum set of permissions needed for the workflow's tasks. Since the workflow only checks out code, installs dependencies, uses secrets, and runs build/test without modifying the repository or acting on issues/pull-requests, `contents: read` is generally sufficient. This change should be made near the top of the `.github/workflows/main.yml` file, just below the workflow `name:` and before `on:` (so that it covers all jobs unless overridden).

**Required changes:** Insert the following block:
```yaml
permissions:
  contents: read
```
**Location:** Place just below `name: Main` (line 1) and above `on:` (line 3).  
No new imports or packages are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
