### PR TITLE
feat: add Google Maps map provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Google Maps provider (`provider: "google"`) via Map Tiles API session + 2D satellite XYZ tiles
+
 ## [1.0.7] - 2026-07-17
 
 ### Added

--- a/docs/pages/map-providers.mdx
+++ b/docs/pages/map-providers.mdx
@@ -14,10 +14,10 @@ import { Callout } from "nextra/components";
 | [TMS](./map-providers/tms)         | Custom raster tile URLs (COG, XYZ pyramids) | Optional       |
 | [WMS](./map-providers/wms)         | OGC WMS GetMap (e.g. Geobasis NRW orthophotos) | None (public)  |
 | [OpenAerialMap](./map-providers/oam) | HOT / OAM aerial orthophotos via STAC + TiTiler | None (public) |
-| Google Maps                        | 🚧 Coming Soon - Global satellite imagery | -              |
+| [Google Maps](./map-providers/google) | Global satellite via Map Tiles API (session + XYZ) | API Key |
 
 <Callout type="info" emoji="💡">
-  **Geobase** — your own COG imagery with full control. **Mapbox / ESRI** — ready-to-use
+  **Geobase** — your own COG imagery with full control. **Mapbox / ESRI / Google** — ready-to-use
   global satellite coverage. **TMS** — any raster `{z}/{x}/{y}` URL. **WMS** — OGC GetMap
   endpoints. **OAM** — community aerial imagery from OpenAerialMap / HOT. See [Serving raster tiles](./map-providers/serving-raster-tiles) for COG and
   tile-server options.

--- a/docs/pages/map-providers/_meta.js
+++ b/docs/pages/map-providers/_meta.js
@@ -5,5 +5,6 @@ export default {
   tms: "TMS",
   wms: "WMS",
   oam: "OpenAerialMap",
+  google: "Google Maps",
   "serving-raster-tiles": "Serving Raster Tiles",
 };

--- a/docs/pages/map-providers/google.mdx
+++ b/docs/pages/map-providers/google.mdx
@@ -49,9 +49,10 @@ type GoogleMapsParams = {
 ## Notes
 
 - **Not free** — Map Tiles API is billed per request; enable the API in your GCP project.
+- **API key restrictions** — Map Tiles is a **web service**. Do **not** use an HTTP-referrer–restricted key (Maps JavaScript keys). Use **no application restriction** or **IP** restriction. Referrer-restricted keys often fail with `401 API keys are not supported` / `CREDENTIALS_MISSING`.
+- **Browser apps** — prefer a same-origin proxy that keeps the key server-side (see live-examples `/api/google-tiles`).
 - **Terms of Service** — follow [Map Tiles API policies](https://developers.google.com/maps/documentation/tile/policies) (attribution, caching limits). Do not scrape unofficial `mt*.google.com` tile hosts.
 - **Map UI** — MapLibre cannot legally use Google tiles as a basemap in most cases. Prefer ESRI/Mapbox/OAM for map display and Google for **inference**, or use the Google Maps JavaScript SDK for the map layer.
-- **CORS** — browser apps may need a same-origin proxy for `tile.googleapis.com` depending on deployment.
 
 ## References
 

--- a/docs/pages/map-providers/google.mdx
+++ b/docs/pages/map-providers/google.mdx
@@ -1,0 +1,60 @@
+import { Callout } from "nextra/components";
+
+# Google Maps
+
+> Global satellite imagery via the Google Map Tiles API (session + XYZ)
+
+Use Google's **Map Tiles API** 2D satellite tiles for GeoAI inference. Requires a Google Maps Platform API key with **Map Tiles API** enabled (billing required).
+
+## Setup
+
+```typescript
+import { geoai } from "geoai";
+
+const pipeline = await geoai.pipeline([{ task: "building-detection" }], {
+  provider: "google",
+  apiKey: process.env.GOOGLE_MAPS_API_KEY!,
+  // optional: mapType: "satellite",
+  // optional: sessionToken: "...", // reuse a pre-created session
+});
+
+const results = await pipeline.inference({
+  inputs: { polygon: myPolygon },
+  mapSourceParams: { zoomLevel: 18 },
+});
+```
+
+<Callout type="info" emoji="🔑">
+  The provider creates a Map Tiles **session** (`POST /v1/createSession`) on
+  first image fetch, caches it, and refreshes near expiry. Tile requests use
+  `GET /v1/2dtiles/{z}/{x}/{y}?session=…&key=…`.
+</Callout>
+
+## Parameters
+
+```typescript
+type GoogleMapsParams = {
+  provider: "google";
+  apiKey: string;
+  mapType?: "satellite" | "roadmap" | "terrain"; // default satellite
+  language?: string; // default en-US
+  region?: string; // default US
+  sessionToken?: string; // optional pre-created session
+  attribution?: string;
+  tileSize?: number;
+  headers?: Record<string, string>;
+};
+```
+
+## Notes
+
+- **Not free** — Map Tiles API is billed per request; enable the API in your GCP project.
+- **Terms of Service** — follow [Map Tiles API policies](https://developers.google.com/maps/documentation/tile/policies) (attribution, caching limits). Do not scrape unofficial `mt*.google.com` tile hosts.
+- **Map UI** — MapLibre cannot legally use Google tiles as a basemap in most cases. Prefer ESRI/Mapbox/OAM for map display and Google for **inference**, or use the Google Maps JavaScript SDK for the map layer.
+- **CORS** — browser apps may need a same-origin proxy for `tile.googleapis.com` depending on deployment.
+
+## References
+
+- [Map Tiles API overview](https://developers.google.com/maps/documentation/tile/overview)
+- [Session tokens](https://developers.google.com/maps/documentation/tile/session_tokens)
+- [Satellite tiles](https://developers.google.com/maps/documentation/tile/satellite)

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -438,9 +438,9 @@ Planned backlog (repo): [ROADMAP.md](https://github.com/decision-labs/geoai.js/b
 | [TMS](./map-providers/tms)         | Custom raster tile URLs (COG, XYZ pyramids) | Optional       |
 | [WMS](./map-providers/wms)         | OGC WMS GetMap (e.g. Geobasis NRW orthophotos) | None (public)  |
 | [OpenAerialMap](./map-providers/oam) | HOT / OAM aerial orthophotos via STAC + TiTiler | None (public) |
-| Google Maps                        | 🚧 Coming Soon - Global satellite imagery | -              |
+| [Google Maps](./map-providers/google) | Global satellite via Map Tiles API (session + XYZ) | API Key |
 
-> **Geobase** — your own COG imagery with full control. **Mapbox / ESRI** — ready-to-use
+> **Geobase** — your own COG imagery with full control. **Mapbox / ESRI / Google** — ready-to-use
 > global satellite coverage. **TMS** — any raster `{z}/{x}/{y}` URL. **WMS** — OGC GetMap
 > endpoints. **OAM** — community aerial imagery from OpenAerialMap / HOT. See [Serving raster tiles](./map-providers/serving-raster-tiles) for COG and
 > tile-server options.
@@ -2968,6 +2968,68 @@ type GeobaseParams = {
 
 > Serves your own Cloud Optimized GeoTIFF (COG) imagery. Task compatibility
 > depends on your COG specifications (resolution, bands, etc.)
+
+---
+
+<!-- map-providers/google.mdx -->
+<!-- https://docs.geobase.app/geoai/map-providers/google -->
+
+# Google Maps
+
+> Global satellite imagery via the Google Map Tiles API (session + XYZ)
+
+Use Google's **Map Tiles API** 2D satellite tiles for GeoAI inference. Requires a Google Maps Platform API key with **Map Tiles API** enabled (billing required).
+
+## Setup
+
+```typescript
+import { geoai } from "geoai";
+
+const pipeline = await geoai.pipeline([{ task: "building-detection" }], {
+  provider: "google",
+  apiKey: process.env.GOOGLE_MAPS_API_KEY!,
+  // optional: mapType: "satellite",
+  // optional: sessionToken: "...", // reuse a pre-created session
+});
+
+const results = await pipeline.inference({
+  inputs: { polygon: myPolygon },
+  mapSourceParams: { zoomLevel: 18 },
+});
+```
+
+> The provider creates a Map Tiles **session** (`POST /v1/createSession`) on
+> first image fetch, caches it, and refreshes near expiry. Tile requests use
+> `GET /v1/2dtiles/{z}/{x}/{y}?session=…&key=…`.
+
+## Parameters
+
+```typescript
+type GoogleMapsParams = {
+  provider: "google";
+  apiKey: string;
+  mapType?: "satellite" | "roadmap" | "terrain"; // default satellite
+  language?: string; // default en-US
+  region?: string; // default US
+  sessionToken?: string; // optional pre-created session
+  attribution?: string;
+  tileSize?: number;
+  headers?: Record<string, string>;
+};
+```
+
+## Notes
+
+- **Not free** — Map Tiles API is billed per request; enable the API in your GCP project.
+- **Terms of Service** — follow [Map Tiles API policies](https://developers.google.com/maps/documentation/tile/policies) (attribution, caching limits). Do not scrape unofficial `mt*.google.com` tile hosts.
+- **Map UI** — MapLibre cannot legally use Google tiles as a basemap in most cases. Prefer ESRI/Mapbox/OAM for map display and Google for **inference**, or use the Google Maps JavaScript SDK for the map layer.
+- **CORS** — browser apps may need a same-origin proxy for `tile.googleapis.com` depending on deployment.
+
+## References
+
+- [Map Tiles API overview](https://developers.google.com/maps/documentation/tile/overview)
+- [Session tokens](https://developers.google.com/maps/documentation/tile/session_tokens)
+- [Satellite tiles](https://developers.google.com/maps/documentation/tile/satellite)
 
 ---
 

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -3021,9 +3021,10 @@ type GoogleMapsParams = {
 ## Notes
 
 - **Not free** — Map Tiles API is billed per request; enable the API in your GCP project.
+- **API key restrictions** — Map Tiles is a **web service**. Do **not** use an HTTP-referrer–restricted key (Maps JavaScript keys). Use **no application restriction** or **IP** restriction. Referrer-restricted keys often fail with `401 API keys are not supported` / `CREDENTIALS_MISSING`.
+- **Browser apps** — prefer a same-origin proxy that keeps the key server-side (see live-examples `/api/google-tiles`).
 - **Terms of Service** — follow [Map Tiles API policies](https://developers.google.com/maps/documentation/tile/policies) (attribution, caching limits). Do not scrape unofficial `mt*.google.com` tile hosts.
 - **Map UI** — MapLibre cannot legally use Google tiles as a basemap in most cases. Prefer ESRI/Mapbox/OAM for map display and Google for **inference**, or use the Google Maps JavaScript SDK for the map layer.
-- **CORS** — browser apps may need a same-origin proxy for `tile.googleapis.com` depending on deployment.
 
 ## References
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -1,6 +1,6 @@
 # GeoAI.js
 
-> JavaScript library for running geospatial AI models (detection, segmentation, classification, DINOv3 features) in the browser against satellite/aerial imagery from ESRI, Mapbox, Geobase, TMS, WMS, or OpenAerialMap.
+> JavaScript library for running geospatial AI models (detection, segmentation, classification, DINOv3 features) in the browser against satellite/aerial imagery from ESRI, Mapbox, Geobase, TMS, WMS, OpenAerialMap, or Google Maps.
 
 Package: `geoai` on npm. Peer deps: `@huggingface/transformers`, `onnxruntime-web`.
 
@@ -23,6 +23,7 @@ Package: `geoai` on npm. Peer deps: `@huggingface/transformers`, `onnxruntime-we
 - [TMS](https://docs.geobase.app/geoai/map-providers/tms): Custom `{z}/{x}/{y}` raster tiles
 - [WMS](https://docs.geobase.app/geoai/map-providers/wms): OGC GetMap endpoints
 - [OpenAerialMap](https://docs.geobase.app/geoai/map-providers/oam): HOT / OAM aerial orthophotos (STAC + TiTiler)
+- [Google Maps](https://docs.geobase.app/geoai/map-providers/google): Map Tiles API satellite (session + XYZ)
 - [Serving raster tiles](https://docs.geobase.app/geoai/map-providers/serving-raster-tiles): COG → tile workflows
 
 ## Supported tasks

--- a/examples/live-examples-nextjs/src/app/api/google-tiles/[...path]/route.ts
+++ b/examples/live-examples-nextjs/src/app/api/google-tiles/[...path]/route.ts
@@ -1,0 +1,124 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+function getGoogleMapsApiKey(): string | undefined {
+  return (
+    process.env.GOOGLE_MAPS_API_KEY ||
+    process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY ||
+    undefined
+  );
+}
+
+/**
+ * Proxy Google Map Tiles API so the browser never needs a referrer-restricted
+ * (or public) API key. Map Tiles is a web service — use a server-side key with
+ * no HTTP-referrer restriction (IP or unrestricted).
+ *
+ * Paths mirror Google:
+ * - POST /api/google-tiles/v1/createSession
+ * - GET  /api/google-tiles/v1/2dtiles/{z}/{x}/{y}?session=...
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> }
+) {
+  const key = getGoogleMapsApiKey();
+  if (!key) {
+    return NextResponse.json(
+      {
+        error:
+          'GOOGLE_MAPS_API_KEY (or NEXT_PUBLIC_GOOGLE_MAPS_API_KEY) is not configured',
+      },
+      { status: 500 }
+    );
+  }
+
+  const resolved = await params;
+  const path = resolved.path.join('/');
+  if (path !== 'v1/createSession') {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  let body: unknown = {};
+  try {
+    body = await request.json();
+  } catch {
+    body = {};
+  }
+
+  const upstream = await fetch(
+    `https://tile.googleapis.com/v1/createSession?key=${encodeURIComponent(key)}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }
+  );
+
+  const text = await upstream.text();
+  return new NextResponse(text, {
+    status: upstream.status,
+    headers: {
+      'Content-Type': upstream.headers.get('content-type') || 'application/json',
+      'Cache-Control': 'no-store',
+    },
+  });
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> }
+) {
+  const key = getGoogleMapsApiKey();
+  if (!key) {
+    return NextResponse.json(
+      {
+        error:
+          'GOOGLE_MAPS_API_KEY (or NEXT_PUBLIC_GOOGLE_MAPS_API_KEY) is not configured',
+      },
+      { status: 500 }
+    );
+  }
+
+  const resolved = await params;
+  const path = resolved.path.join('/');
+  const match = path.match(/^v1\/2dtiles\/(\d+)\/(\d+)\/(\d+)$/);
+  if (!match) {
+    return NextResponse.json({ error: 'Invalid tile path' }, { status: 400 });
+  }
+
+  const [, z, x, y] = match;
+  const session = request.nextUrl.searchParams.get('session');
+  if (!session) {
+    return NextResponse.json({ error: 'Missing session' }, { status: 400 });
+  }
+
+  const upstreamUrl =
+    `https://tile.googleapis.com/v1/2dtiles/${z}/${x}/${y}` +
+    `?session=${encodeURIComponent(session)}` +
+    `&key=${encodeURIComponent(key)}`;
+
+  const upstream = await fetch(upstreamUrl);
+  if (!upstream.ok) {
+    const errText = await upstream.text().catch(() => '');
+    return NextResponse.json(
+      {
+        error: 'Google tile request failed',
+        status: upstream.status,
+        details: errText.slice(0, 300),
+      },
+      { status: upstream.status }
+    );
+  }
+
+  const headers = new Headers();
+  const contentType = upstream.headers.get('content-type');
+  if (contentType) {
+    headers.set('Content-Type', contentType);
+  }
+  headers.set('Cache-Control', 'public, max-age=3600');
+
+  return new NextResponse(upstream.body, {
+    status: upstream.status,
+    headers,
+  });
+}

--- a/examples/live-examples-nextjs/src/components/MapProviderSelector.tsx
+++ b/examples/live-examples-nextjs/src/components/MapProviderSelector.tsx
@@ -8,6 +8,7 @@ const ALL_PROVIDERS: { value: MapProvider; label: string }[] = [
   { value: "tms", label: "TMS" },
   { value: "wms", label: "WMS (NRW)" },
   { value: "oam", label: "OAM (HOT)" },
+  { value: "google", label: "Google Maps" },
 ];
 
 interface MapProviderSelectorProps {
@@ -55,6 +56,8 @@ export const MapProviderSelector: React.FC<MapProviderSelectorProps> = ({
             <span className="text-gray-500 text-xs">🗺️</span>
           ) : value === "oam" ? (
             <span className="text-gray-500 text-xs">✈️</span>
+          ) : value === "google" ? (
+            <span className="text-gray-500 text-xs">G</span>
           ) : (
             <span className="text-gray-500 text-xs">🛰️</span>
           )}

--- a/examples/live-examples-nextjs/src/config.ts
+++ b/examples/live-examples-nextjs/src/config.ts
@@ -1,4 +1,4 @@
-import { GeobaseParams, ProviderParams } from "geoai";
+import { GeobaseParams, GoogleMapsParams } from "geoai";
 
 export const ESRI_CONFIG = {
   provider: "esri" as const,
@@ -19,6 +19,14 @@ export const MAPBOX_CONFIG = {
   provider: "mapbox" as const,
   apiKey: process.env.NEXT_PUBLIC_MAPBOX_TOKEN || "test",
   style: "mapbox://styles/mapbox/satellite-v9",
+};
+
+/** Inference uses Google Map Tiles API; MapLibre basemap stays on ESRI (ToS). */
+export const GOOGLE_CONFIG: GoogleMapsParams = {
+  provider: "google",
+  apiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || "",
+  mapType: "satellite",
+  attribution: "© Google Maps / Map Tiles API",
 };
 
 

--- a/examples/live-examples-nextjs/src/config.ts
+++ b/examples/live-examples-nextjs/src/config.ts
@@ -21,11 +21,14 @@ export const MAPBOX_CONFIG = {
   style: "mapbox://styles/mapbox/satellite-v9",
 };
 
-/** Inference uses Google Map Tiles API; MapLibre basemap stays on ESRI (ToS). */
+/** Inference via Google Map Tiles through a same-origin proxy (server holds the key). */
 export const GOOGLE_CONFIG: GoogleMapsParams = {
   provider: "google",
-  apiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || "",
+  // Key is injected by /api/google-tiles; not sent from the browser.
+  apiKey: "proxy",
   mapType: "satellite",
+  tileApiUrl: `${process.env.NEXT_PUBLIC_BASE_PATH || ""}/api/google-tiles`,
+  includeApiKey: false,
   attribution: "© Google Maps / Map Tiles API",
 };
 

--- a/examples/live-examples-nextjs/src/types.ts
+++ b/examples/live-examples-nextjs/src/types.ts
@@ -1,1 +1,1 @@
-export type MapProvider = "geobase" | "mapbox" | "esri" | "tms" | "wms" | "oam";
+export type MapProvider = "geobase" | "mapbox" | "esri" | "tms" | "wms" | "oam" | "google";

--- a/examples/live-examples-nextjs/src/utils/mapStyleUtils.ts
+++ b/examples/live-examples-nextjs/src/utils/mapStyleUtils.ts
@@ -156,7 +156,7 @@ export function createBaseMapStyle(config: MapStyleConfig, options: BaseMapStyle
         minzoom: 0,
         maxzoom: maxZoom,
         layout: {
-          visibility: mapProvider === "esri" ? "visible" : "none",
+          visibility: mapProvider === "esri" || mapProvider === "google" ? "visible" : "none",
         },
       },
       {

--- a/examples/live-examples-nextjs/src/utils/optimalParamsUtil.ts
+++ b/examples/live-examples-nextjs/src/utils/optimalParamsUtil.ts
@@ -24,6 +24,7 @@ const PROVIDER_ZOOM_FALLBACK: Record<string, string> = {
   tms: 'esri',
   wms: 'esri',
   oam: 'esri',
+  google: 'mapbox',
 };
 
 export const getOptimumZoom = (task: string, provider: string): number | null => {

--- a/examples/live-examples-nextjs/src/utils/providerConfig.ts
+++ b/examples/live-examples-nextjs/src/utils/providerConfig.ts
@@ -1,6 +1,6 @@
 import type { OamParams, ProviderParams, TmsParams, WmsParams } from 'geoai';
 import type maplibregl from 'maplibre-gl';
-import { ESRI_CONFIG, GEOBASE_CONFIG, MAPBOX_CONFIG } from '../config';
+import { ESRI_CONFIG, GEOBASE_CONFIG, GOOGLE_CONFIG, MAPBOX_CONFIG } from '../config';
 import type { MapProvider } from '../types';
 
 /** ESRI World Imagery as TMS — same tiles, `provider: "tms"` pipeline. */
@@ -105,6 +105,8 @@ export function getProviderParams(
       return WMS_CONFIG;
     case 'oam':
       return OAM_CONFIG;
+    case 'google':
+      return GOOGLE_CONFIG;
     default:
       return ESRI_CONFIG;
   }

--- a/skills/geoai/SKILL.md
+++ b/skills/geoai/SKILL.md
@@ -92,6 +92,7 @@ Full task notes, defaults, and chain rules: [tasks.md](tasks.md).
 | `tms` | Optional | Any `{z}/{x}/{y}` raster tiles |
 | `wms` | Usually none | OGC GetMap endpoints |
 | `oam` | None | OpenAerialMap / HOT aerial imagery |
+| `google` | API key | Google Map Tiles API satellite |
 
 Configs: [providers.md](providers.md).
 

--- a/skills/geoai/providers.md
+++ b/skills/geoai/providers.md
@@ -93,6 +93,23 @@ Public aerial orthophotos via STAC + TiTiler. No API key.
 Docs: https://docs.geobase.app/geoai/map-providers/oam
 Example: `examples/07-oam-quickstart`
 
+## Google Maps (Map Tiles API)
+
+Global satellite imagery. Requires a Google Maps Platform API key with Map Tiles API enabled.
+
+```typescript
+{
+  provider: 'google',
+  apiKey: process.env.GOOGLE_MAPS_API_KEY,
+  // optional: mapType: 'satellite',
+  // optional: sessionToken: '...',
+}
+```
+
+Creates a session on first fetch (`/v1/createSession`), then requests
+`/v1/2dtiles/{z}/{x}/{y}`. Follow Google attribution and caching policies.
+Docs: https://docs.geobase.app/geoai/map-providers/google
+
 ## Map source params (all providers)
 
 ```typescript

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -104,6 +104,13 @@ export type GoogleMapsParams = {
   region?: string;
   /** Optional pre-created session token (skips createSession until expiry). */
   sessionToken?: string;
+  /** Override API root (e.g. same-origin proxy). Default https://tile.googleapis.com */
+  tileApiUrl?: string;
+  /**
+   * When false, omit `key=` from requests (proxy injects the server key).
+   * Default true.
+   */
+  includeApiKey?: boolean;
   attribution?: string;
   tileSize?: number;
   headers?: Record<string, string>;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -94,6 +94,21 @@ export type OamParams = {
   headers?: Record<string, string>;
 };
 
+export type GoogleMapsParams = {
+  provider: "google";
+  /** Google Maps Platform API key with Map Tiles API enabled. */
+  apiKey: string;
+  /** 2D map type for the session (default satellite). */
+  mapType?: "satellite" | "roadmap" | "terrain";
+  language?: string;
+  region?: string;
+  /** Optional pre-created session token (skips createSession until expiry). */
+  sessionToken?: string;
+  attribution?: string;
+  tileSize?: number;
+  headers?: Record<string, string>;
+};
+
 export interface InferenceInputs {
   polygon: GeoJSON.Feature;
   classLabel?: string;
@@ -130,7 +145,8 @@ export type ProviderParams =
   | EsriParams
   | TmsParams
   | WmsParams
-  | OamParams;
+  | OamParams
+  | GoogleMapsParams;
 
 export type HuggingFaceModelTask =
   | "mask-generation"

--- a/src/data_providers/google.ts
+++ b/src/data_providers/google.ts
@@ -17,8 +17,13 @@ export interface GoogleConfig {
    * one via `POST /v1/createSession` and refreshes near expiry.
    */
   sessionToken?: string;
-  /** Session API root (default https://tile.googleapis.com). */
+  /** Session/tile API root (default https://tile.googleapis.com). */
   tileApiUrl?: string;
+  /**
+   * When false, omit `key=` from createSession/tile URLs (use with a same-origin
+   * proxy that injects the server-side API key). Default true.
+   */
+  includeApiKey?: boolean;
   attribution?: string;
   tileSize?: number;
   headers?: Record<string, string>;
@@ -36,9 +41,13 @@ export interface GoogleSessionResponse {
 
 export function buildGoogleCreateSessionUrl(
   apiKey: string,
-  tileApiUrl: string = DEFAULT_GOOGLE_TILE_API_URL
+  tileApiUrl: string = DEFAULT_GOOGLE_TILE_API_URL,
+  includeApiKey: boolean = true
 ): string {
   const base = tileApiUrl.replace(/\/$/, "");
+  if (!includeApiKey) {
+    return `${base}/v1/createSession`;
+  }
   return `${base}/v1/createSession?key=${encodeURIComponent(apiKey)}`;
 }
 
@@ -48,14 +57,17 @@ export function buildGoogleTileUrl(
   y: number,
   sessionToken: string,
   apiKey: string,
-  tileApiUrl: string = DEFAULT_GOOGLE_TILE_API_URL
+  tileApiUrl: string = DEFAULT_GOOGLE_TILE_API_URL,
+  includeApiKey: boolean = true
 ): string {
   const base = tileApiUrl.replace(/\/$/, "");
-  return (
+  let url =
     `${base}/v1/2dtiles/${z}/${x}/${y}` +
-    `?session=${encodeURIComponent(sessionToken)}` +
-    `&key=${encodeURIComponent(apiKey)}`
-  );
+    `?session=${encodeURIComponent(sessionToken)}`;
+  if (includeApiKey) {
+    url += `&key=${encodeURIComponent(apiKey)}`;
+  }
+  return url;
 }
 
 /**
@@ -68,18 +80,21 @@ export async function createGoogleSession(options: {
   language?: string;
   region?: string;
   tileApiUrl?: string;
+  includeApiKey?: boolean;
   headers?: Record<string, string>;
   fetchImpl?: typeof fetch;
 }): Promise<GoogleSessionResponse> {
   const apiKey = options.apiKey;
-  if (!apiKey) {
+  const includeApiKey = options.includeApiKey !== false;
+  if (includeApiKey && !apiKey) {
     throw new Error("Google Maps provider requires an apiKey");
   }
 
   const fetchImpl = options.fetchImpl || fetch;
   const url = buildGoogleCreateSessionUrl(
     apiKey,
-    options.tileApiUrl || DEFAULT_GOOGLE_TILE_API_URL
+    options.tileApiUrl || DEFAULT_GOOGLE_TILE_API_URL,
+    includeApiKey
   );
 
   const response = await fetchImpl(url, {
@@ -115,6 +130,7 @@ export class GoogleMaps extends MapSource {
   language: string;
   region: string;
   tileApiUrl: string;
+  includeApiKey: boolean;
   attribution: string;
   tileSize: number;
   headers?: Record<string, string>;
@@ -126,10 +142,11 @@ export class GoogleMaps extends MapSource {
 
   constructor(config: GoogleConfig) {
     super();
-    if (!config.apiKey) {
+    this.includeApiKey = config.includeApiKey !== false;
+    if (this.includeApiKey && !config.apiKey) {
       throw new Error("Google Maps provider requires an apiKey");
     }
-    this.apiKey = config.apiKey;
+    this.apiKey = config.apiKey || "";
     this.mapType = config.mapType || DEFAULT_GOOGLE_MAP_TYPE;
     this.language = config.language || "en-US";
     this.region = config.region || "US";
@@ -169,6 +186,7 @@ export class GoogleMaps extends MapSource {
       language: this.language,
       region: this.region,
       tileApiUrl: this.tileApiUrl,
+      includeApiKey: this.includeApiKey,
       headers: this.headers,
       fetchImpl: this.fetchImpl,
     });
@@ -217,7 +235,8 @@ export class GoogleMaps extends MapSource {
       y,
       instance.sessionToken,
       instance.apiKey,
-      instance.tileApiUrl
+      instance.tileApiUrl,
+      instance.includeApiKey
     );
   }
 }

--- a/src/data_providers/google.ts
+++ b/src/data_providers/google.ts
@@ -1,0 +1,223 @@
+import { MapSource } from "./mapsource";
+
+export const DEFAULT_GOOGLE_TILE_API_URL = "https://tile.googleapis.com";
+export const DEFAULT_GOOGLE_MAP_TYPE = "satellite";
+
+export type GoogleMapType = "satellite" | "roadmap" | "terrain";
+
+export interface GoogleConfig {
+  /** Google Maps Platform API key with Map Tiles API enabled. */
+  apiKey: string;
+  /** 2D map type for the session (default `satellite`). */
+  mapType?: GoogleMapType;
+  language?: string;
+  region?: string;
+  /**
+   * Optional pre-created session token. When omitted, the provider creates
+   * one via `POST /v1/createSession` and refreshes near expiry.
+   */
+  sessionToken?: string;
+  /** Session API root (default https://tile.googleapis.com). */
+  tileApiUrl?: string;
+  attribution?: string;
+  tileSize?: number;
+  headers?: Record<string, string>;
+  /** Injected for tests. */
+  fetchImpl?: typeof fetch;
+}
+
+export interface GoogleSessionResponse {
+  session: string;
+  expiry: string;
+  tileWidth?: number;
+  tileHeight?: number;
+  imageFormat?: string;
+}
+
+export function buildGoogleCreateSessionUrl(
+  apiKey: string,
+  tileApiUrl: string = DEFAULT_GOOGLE_TILE_API_URL
+): string {
+  const base = tileApiUrl.replace(/\/$/, "");
+  return `${base}/v1/createSession?key=${encodeURIComponent(apiKey)}`;
+}
+
+export function buildGoogleTileUrl(
+  z: number,
+  x: number,
+  y: number,
+  sessionToken: string,
+  apiKey: string,
+  tileApiUrl: string = DEFAULT_GOOGLE_TILE_API_URL
+): string {
+  const base = tileApiUrl.replace(/\/$/, "");
+  return (
+    `${base}/v1/2dtiles/${z}/${x}/${y}` +
+    `?session=${encodeURIComponent(sessionToken)}` +
+    `&key=${encodeURIComponent(apiKey)}`
+  );
+}
+
+/**
+ * Create a Map Tiles API session for 2D tiles.
+ * @see https://developers.google.com/maps/documentation/tile/session_tokens
+ */
+export async function createGoogleSession(options: {
+  apiKey: string;
+  mapType?: GoogleMapType;
+  language?: string;
+  region?: string;
+  tileApiUrl?: string;
+  headers?: Record<string, string>;
+  fetchImpl?: typeof fetch;
+}): Promise<GoogleSessionResponse> {
+  const apiKey = options.apiKey;
+  if (!apiKey) {
+    throw new Error("Google Maps provider requires an apiKey");
+  }
+
+  const fetchImpl = options.fetchImpl || fetch;
+  const url = buildGoogleCreateSessionUrl(
+    apiKey,
+    options.tileApiUrl || DEFAULT_GOOGLE_TILE_API_URL
+  );
+
+  const response = await fetchImpl(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(options.headers || {}),
+    },
+    body: JSON.stringify({
+      mapType: options.mapType || DEFAULT_GOOGLE_MAP_TYPE,
+      language: options.language || "en-US",
+      region: options.region || "US",
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(
+      `Google Map Tiles createSession failed (${response.status}): ${body || response.statusText}`
+    );
+  }
+
+  const data = (await response.json()) as GoogleSessionResponse;
+  if (!data.session) {
+    throw new Error("Google Map Tiles createSession returned no session token");
+  }
+  return data;
+}
+
+export class GoogleMaps extends MapSource {
+  apiKey: string;
+  mapType: GoogleMapType;
+  language: string;
+  region: string;
+  tileApiUrl: string;
+  attribution: string;
+  tileSize: number;
+  headers?: Record<string, string>;
+  fetchImpl: typeof fetch;
+
+  sessionToken?: string;
+  /** Unix epoch seconds when the session expires. */
+  sessionExpiry?: number;
+
+  constructor(config: GoogleConfig) {
+    super();
+    if (!config.apiKey) {
+      throw new Error("Google Maps provider requires an apiKey");
+    }
+    this.apiKey = config.apiKey;
+    this.mapType = config.mapType || DEFAULT_GOOGLE_MAP_TYPE;
+    this.language = config.language || "en-US";
+    this.region = config.region || "US";
+    this.tileApiUrl = (
+      config.tileApiUrl || DEFAULT_GOOGLE_TILE_API_URL
+    ).replace(/\/$/, "");
+    this.attribution = config.attribution || "© Google Maps / Map Tiles API";
+    this.tileSize = config.tileSize || 256;
+    this.headers = config.headers;
+    this.fetchImpl = config.fetchImpl || fetch;
+    this.sessionToken = config.sessionToken;
+  }
+
+  private isSessionValid(skewSeconds: number = 60): boolean {
+    if (!this.sessionToken) {
+      return false;
+    }
+    if (this.sessionExpiry == null) {
+      // Explicit sessionToken without expiry — trust until a request fails.
+      return true;
+    }
+    const now = Math.floor(Date.now() / 1000);
+    return this.sessionExpiry - skewSeconds > now;
+  }
+
+  /**
+   * Ensure a valid Map Tiles session exists (create or refresh).
+   */
+  async ensureSession(): Promise<string> {
+    if (this.isSessionValid()) {
+      return this.sessionToken as string;
+    }
+
+    const data = await createGoogleSession({
+      apiKey: this.apiKey,
+      mapType: this.mapType,
+      language: this.language,
+      region: this.region,
+      tileApiUrl: this.tileApiUrl,
+      headers: this.headers,
+      fetchImpl: this.fetchImpl,
+    });
+
+    this.sessionToken = data.session;
+    const expiry = Number(data.expiry);
+    this.sessionExpiry = Number.isFinite(expiry) ? expiry : undefined;
+    if (typeof data.tileWidth === "number") {
+      this.tileSize = data.tileWidth;
+    }
+    return this.sessionToken;
+  }
+
+  async getImage(
+    polygon: any,
+    bands?: number[],
+    expression?: string,
+    zoomLevel?: number,
+    requiresSquare: boolean = false,
+    stitch: boolean = true
+  ) {
+    await this.ensureSession();
+    return super.getImage(
+      polygon,
+      bands,
+      expression,
+      zoomLevel,
+      requiresSquare,
+      stitch
+    );
+  }
+
+  protected getTileUrlFromTileCoords(
+    tileCoords: [number, number, number],
+    instance: GoogleMaps
+  ): string {
+    if (!instance.sessionToken) {
+      throw new Error(
+        "Google Maps session is not ready. Call ensureSession() or getImage() first."
+      );
+    }
+    const [x, y, z] = tileCoords;
+    return buildGoogleTileUrl(
+      z,
+      x,
+      y,
+      instance.sessionToken,
+      instance.apiKey,
+      instance.tileApiUrl
+    );
+  }
+}

--- a/src/models/base_model.ts
+++ b/src/models/base_model.ts
@@ -121,6 +121,8 @@ export abstract class BaseModel {
           language: this.providerParams.language,
           region: this.providerParams.region,
           sessionToken: this.providerParams.sessionToken,
+          tileApiUrl: this.providerParams.tileApiUrl,
+          includeApiKey: this.providerParams.includeApiKey,
           attribution: this.providerParams.attribution,
           tileSize: this.providerParams.tileSize,
           headers: this.providerParams.headers,

--- a/src/models/base_model.ts
+++ b/src/models/base_model.ts
@@ -4,6 +4,7 @@ import { Esri } from "@/data_providers/esri";
 import { Tms } from "@/data_providers/tms";
 import { Wms } from "@/data_providers/wms";
 import { Oam } from "@/data_providers/oam";
+import { GoogleMaps } from "@/data_providers/google";
 import { ProviderParams } from "@/geoai";
 import { PretrainedModelOptions } from "@huggingface/transformers";
 import { GeoRawImage } from "@/types/images/GeoRawImage";
@@ -12,7 +13,15 @@ import { InferenceParams } from "@/core/types";
 export abstract class BaseModel {
   protected static instance: BaseModel | null = null;
   protected providerParams: ProviderParams;
-  protected dataProvider: Mapbox | Geobase | Esri | Tms | Wms | Oam | undefined;
+  protected dataProvider:
+    | Mapbox
+    | Geobase
+    | Esri
+    | Tms
+    | Wms
+    | Oam
+    | GoogleMaps
+    | undefined;
   protected model_id: string;
   protected initialized: boolean = false;
   protected modelParams?: PretrainedModelOptions;
@@ -100,6 +109,18 @@ export abstract class BaseModel {
           asset: this.providerParams.asset,
           itemId: this.providerParams.itemId,
           mosaic: this.providerParams.mosaic,
+          attribution: this.providerParams.attribution,
+          tileSize: this.providerParams.tileSize,
+          headers: this.providerParams.headers,
+        });
+        break;
+      case "google":
+        this.dataProvider = new GoogleMaps({
+          apiKey: this.providerParams.apiKey,
+          mapType: this.providerParams.mapType,
+          language: this.providerParams.language,
+          region: this.providerParams.region,
+          sessionToken: this.providerParams.sessionToken,
           attribution: this.providerParams.attribution,
           tileSize: this.providerParams.tileSize,
           headers: this.providerParams.headers,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -185,6 +185,15 @@ export const parametersChanged = (
         return true;
       }
       break;
+    case "google":
+      if (
+        instance.providerParams?.apiKey !== providerParams?.apiKey ||
+        instance.providerParams?.mapType !== providerParams?.mapType ||
+        instance.providerParams?.sessionToken !== providerParams?.sessionToken
+      ) {
+        return true;
+      }
+      break;
   }
 
   // Compare modelParams if they exist

--- a/test/google.test.ts
+++ b/test/google.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  GoogleMaps,
+  buildGoogleCreateSessionUrl,
+  buildGoogleTileUrl,
+  createGoogleSession,
+  DEFAULT_GOOGLE_TILE_API_URL,
+} from "../src/data_providers/google";
+import { geoai } from "@/geoai";
+
+describe("Google Maps helpers", () => {
+  it("builds createSession URL", () => {
+    const url = buildGoogleCreateSessionUrl("test-key");
+    expect(url).toBe(
+      `${DEFAULT_GOOGLE_TILE_API_URL}/v1/createSession?key=test-key`
+    );
+  });
+
+  it("builds 2d tile URL with session and key", () => {
+    const url = buildGoogleTileUrl(16, 35041, 24355, "sess-abc", "test-key");
+    expect(url).toContain("/v1/2dtiles/16/35041/24355?");
+    expect(url).toContain("session=sess-abc");
+    expect(url).toContain("key=test-key");
+  });
+
+  it("createGoogleSession posts mapType and returns session", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        session: "sess-123",
+        expiry: String(Math.floor(Date.now() / 1000) + 3600),
+        tileWidth: 256,
+        tileHeight: 256,
+        imageFormat: "png",
+      }),
+    });
+
+    const data = await createGoogleSession({
+      apiKey: "test-key",
+      mapType: "satellite",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(data.session).toBe("sess-123");
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(url).toContain("/v1/createSession?key=test-key");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body)).toEqual({
+      mapType: "satellite",
+      language: "en-US",
+      region: "US",
+    });
+  });
+
+  it("createGoogleSession throws on HTTP error", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      statusText: "Forbidden",
+      text: async () => "API key invalid",
+    });
+
+    await expect(
+      createGoogleSession({
+        apiKey: "bad",
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      })
+    ).rejects.toThrow(/createSession failed \(403\)/);
+  });
+});
+
+describe("GoogleMaps provider", () => {
+  it("requires apiKey", () => {
+    expect(() => new GoogleMaps({ apiKey: "" })).toThrow(/apiKey/);
+  });
+
+  it("uses provided sessionToken without createSession", async () => {
+    const fetchImpl = vi.fn();
+    const google = new GoogleMaps({
+      apiKey: "test-key",
+      sessionToken: "prebuilt-session",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const token = await google.ensureSession();
+    expect(token).toBe("prebuilt-session");
+    expect(fetchImpl).not.toHaveBeenCalled();
+
+    const url = google["getTileUrlFromTileCoords"]([1, 2, 3], google);
+    expect(url).toContain("/v1/2dtiles/3/1/2?");
+    expect(url).toContain("session=prebuilt-session");
+  });
+
+  it("creates and caches a session", async () => {
+    const expiry = Math.floor(Date.now() / 1000) + 7200;
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        session: "sess-new",
+        expiry: String(expiry),
+        tileWidth: 256,
+      }),
+    });
+
+    const google = new GoogleMaps({
+      apiKey: "test-key",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const first = await google.ensureSession();
+    const second = await google.ensureSession();
+    expect(first).toBe("sess-new");
+    expect(second).toBe("sess-new");
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it("refreshes session when expired", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          session: "sess-old",
+          expiry: String(Math.floor(Date.now() / 1000) - 10),
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          session: "sess-fresh",
+          expiry: String(Math.floor(Date.now() / 1000) + 3600),
+        }),
+      });
+
+    const google = new GoogleMaps({
+      apiKey: "test-key",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    // First call stores an already-expired token
+    await google.ensureSession();
+    const refreshed = await google.ensureSession();
+    expect(refreshed).toBe("sess-fresh");
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws if tile URL requested before session", () => {
+    const google = new GoogleMaps({ apiKey: "test-key" });
+    expect(() => google["getTileUrlFromTileCoords"]([0, 0, 1], google)).toThrow(
+      /session is not ready/
+    );
+  });
+});
+
+describe("Google Maps pipeline wiring", () => {
+  it("initializes a pipeline with provider google", async () => {
+    const pipeline = await geoai.pipeline([{ task: "object-detection" }], {
+      provider: "google",
+      apiKey: "test-key",
+      sessionToken: "sess-test",
+    });
+    expect(pipeline).toBeDefined();
+    expect(typeof pipeline.inference).toBe("function");
+  }, 120_000);
+});

--- a/test/google.test.ts
+++ b/test/google.test.ts
@@ -71,6 +71,32 @@ describe("Google Maps helpers", () => {
 });
 
 describe("GoogleMaps provider", () => {
+  it("omits api key from URLs when includeApiKey is false", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        session: "sess-proxy",
+        expiry: String(Math.floor(Date.now() / 1000) + 3600),
+      }),
+    });
+
+    const google = new GoogleMaps({
+      apiKey: "unused",
+      includeApiKey: false,
+      tileApiUrl: "http://localhost/api/google-tiles",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    await google.ensureSession();
+    const [url] = fetchImpl.mock.calls[0];
+    expect(url).toBe("http://localhost/api/google-tiles/v1/createSession");
+    expect(url).not.toContain("key=");
+
+    const tileUrl = google["getTileUrlFromTileCoords"]([1, 2, 3], google);
+    expect(tileUrl).toContain("/v1/2dtiles/3/1/2?session=sess-proxy");
+    expect(tileUrl).not.toContain("key=");
+  });
+
   it("requires apiKey", () => {
     expect(() => new GoogleMaps({ apiKey: "" })).toThrow(/apiKey/);
   });


### PR DESCRIPTION
## Summary
- Add `provider: \"google\"` using Google Map Tiles API (createSession + `/v1/2dtiles/{z}/{x}/{y}`)
- Session cache/refresh, optional pre-built `sessionToken`, unit + pipeline wiring tests
- Docs (`google.mdx`), skill, CHANGELOG; note ToS/attribution/CORS caveats

## Test plan
- [x] `pnpm exec vitest run test/google.test.ts` (10 passed)
- [x] Manual smoke with a real Map Tiles API key (optional)
- [x] Confirm docs page renders: `/map-providers/google`

## Notes
- MapLibre basemap with Google tiles is intentionally out of scope (ToS); use Google for inference, another provider for map UI.
- Browser CORS may require a proxy in some deployments.